### PR TITLE
Memolist getting refactor

### DIFF
--- a/web-api/memo.lib.js
+++ b/web-api/memo.lib.js
@@ -60,13 +60,14 @@ export const MemoLib = {
   searchMemoCouchDocs: async (regex) => {
     try {
       const response = await axios.post(`${COUCHDB_DATABASE_URL}/_find`, {
-        "selector": {
+        selector: {
           _id: { $gt: null },
           $or: [
             { content: { $elemMatch: { $regex: regex } } },
             { title: { $regex: regex } }
           ]
-        }
+        },
+        fields: ['_id', 'title', 'taxonomy', 'created_at', 'updated_at'],
       });
       return response['data']['docs'].length ? response['data']['docs'] : [];
     } catch (error) {

--- a/web-ui/store/memos.ts
+++ b/web-ui/store/memos.ts
@@ -19,6 +19,7 @@ export const state = () => ({
   memoEditor: {
     editorLoadedWithDocument: true,
     couchDoc: null,
+    originalDoc: {},
   },
   confirmModal: {
     isActive: false,
@@ -217,6 +218,7 @@ export const mutations = {
   //  state.search.results = searchResults;
   // },
   setMemoInEditor(state, memoObject) {
+    state.memoEditor.originalDoc = { ...memoObject }
     state.memoEditor.couchDoc = memoObject
   },
   setMemoEditorContent(state, newContent) {
@@ -329,11 +331,7 @@ export const getters = {
   // and extend `title` and `taxonomy` input widgets to also fire change events.
   editorDocumentChanged(state, getters) {
     if (getters.editorLoadedWithDocument) return false
-    const originalDocument = state.collection.filter(
-      (memo) =>
-        memo._id === state.memoEditor.couchDoc._id &&
-        memo._rev === state.memoEditor.couchDoc._rev
-    )[0] || { title: null, content: [], taxonomy: [] }
+    const originalDocument = state.memoEditor.originalDoc
     const originalDocumentSerializedContent = JSON.stringify({
       title: originalDocument.title,
       content: originalDocument.content,

--- a/web-ui/store/memos.ts
+++ b/web-ui/store/memos.ts
@@ -307,7 +307,6 @@ export const getters = {
   memosList(state) {
     return state.collection.map((item) => {
       return Object.assign({}, item, {
-        content: item.content[0],
         stats: {
           'wc -l': item.content?.length,
           tags: item.taxonomy?.length ? `[${item.taxonomy.join(', ')}]` : '0',


### PR DESCRIPTION
- [x] CouchDB (and inherently Web API memo lists to return memos stripped of `content` and `attachment` itself) (on search)